### PR TITLE
Docker file update to fix issue with gcc

### DIFF
--- a/ctt-server/Dockerfile
+++ b/ctt-server/Dockerfile
@@ -5,7 +5,11 @@ WORKDIR /usr/src/app
 
 COPY requirements.txt /usr/src/app/
 
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN apk --update add python py-pip openssl ca-certificates py-openssl wget git
+RUN apk --update add --virtual build-dependencies libffi-dev openssl-dev python-dev py-pip build-base \
+  && pip install --upgrade pip \
+  && pip install -r requirements.txt \
+  && apk del build-dependencies
 
 COPY . /usr/src/app
 


### PR DESCRIPTION
Related to the Issue: https://github.com/radon-h2020/radon-ctt/issues/63

The command:
docker build -t openapi_server .
fails with error:
unable to execute 'gcc': No such file or directory

The proposed change should solve this issue. I tested this change and was successfully able to run the CTT server through docker and access the UI over 8080.